### PR TITLE
Add FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,23 @@ You will be prompted for a description of the vibe you want. After authorising w
 - `user_data.py` – helper that fetches your top tracks using the Spotify Web API.
 
 Enjoy your personalised DJ set!
+
+## API Server
+
+An optional FastAPI server is provided in `api.py` to expose REST
+endpoints for creating playlists. Install `fastapi` and `uvicorn` and
+run:
+
+```bash
+uvicorn api:app
+```
+
+Key endpoints:
+
+- `GET /login` – obtain the Spotify authorisation URL.
+- `GET /callback` – OAuth redirect URI.
+- `POST /vibe` – set the desired vibe prompt.
+- `GET /vibe` – retrieve the currently stored vibe.
+- `POST /playlist` – generate and save the playlist to your account.
+- `GET /profile` – return the authenticated user's profile.
+

--- a/api.py
+++ b/api.py
@@ -1,0 +1,84 @@
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from spotipy.oauth2 import SpotifyOAuth
+import spotipy
+from dotenv import load_dotenv
+import datetime
+from create_playlist import create_playlist, add_tracks_to_playlist
+from user_data import get_user_top_tracks
+from llm_dj import prompt_llm, get_spotify_tracks
+
+load_dotenv()
+
+app = FastAPI()
+
+sp_oauth = SpotifyOAuth(
+    scope="user-top-read playlist-modify-public playlist-modify-private user-read-private",
+    open_browser=False
+)
+
+# In-memory storage for user prompts
+user_prompts = {}
+
+@app.get("/login")
+def login():
+    auth_url = sp_oauth.get_authorize_url()
+    return {"auth_url": auth_url}
+
+@app.get("/callback")
+def callback(request: Request):
+    code = request.query_params.get("code")
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing code")
+    token_info = sp_oauth.get_access_token(code)
+    if not token_info:
+        raise HTTPException(status_code=400, detail="Failed to get token")
+    request.session = {}
+    request.session['token_info'] = token_info
+    return RedirectResponse(url="/")
+
+@app.post("/vibe")
+def set_vibe(vibe: str, request: Request):
+    if not vibe:
+        raise HTTPException(status_code=400, detail="Vibe required")
+    request.session = getattr(request, 'session', {})
+    request.session['vibe'] = vibe
+    user_prompts['vibe'] = vibe
+    return {"vibe": vibe}
+
+@app.get("/vibe")
+def get_vibe():
+    vibe = user_prompts.get('vibe')
+    if not vibe:
+        raise HTTPException(status_code=404, detail="Vibe not set")
+    return {"vibe": vibe}
+
+@app.post("/playlist")
+def make_playlist(request: Request):
+    vibe = user_prompts.get('vibe')
+    if not vibe:
+        raise HTTPException(status_code=400, detail="No vibe set")
+    token_info = sp_oauth.get_cached_token()
+    if not token_info:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    sp = spotipy.Spotify(auth=token_info['access_token'])
+    top_tracks = get_user_top_tracks()
+    setlist = prompt_llm(vibe, top_tracks)
+    setlist_spotify = get_spotify_tracks(setlist)
+    track_uris = [t['uri'] for t in setlist_spotify]
+    user_profile = sp.current_user()
+    user_id = user_profile['id']
+    today = datetime.datetime.now().strftime("%Y-%m-%d")
+    playlist_name = f"LLM DJ Set – {today}"
+    playlist_desc = f'Vibe: "{vibe}"'
+    playlist_id, playlist_url = create_playlist(user_id, playlist_name, playlist_desc)
+    add_tracks_to_playlist(playlist_id, track_uris)
+    return {"playlist_url": playlist_url}
+
+@app.get("/profile")
+def profile():
+    token_info = sp_oauth.get_cached_token()
+    if not token_info:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    sp = spotipy.Spotify(auth=token_info['access_token'])
+    return sp.current_user()


### PR DESCRIPTION
## Summary
- add `api.py` implementing a FastAPI backend with Spotify OAuth and playlist creation
- document how to use the API in README

## Testing
- `python -m py_compile api.py create_playlist.py llm_dj.py user_data.py`


------
https://chatgpt.com/codex/tasks/task_e_685b019fcfd08326b01d486755197654