### PR TITLE
Remove Set Vibe button

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Key endpoints:
 
 - `GET /login` – obtain the Spotify authorisation URL.
 - `GET /callback` – OAuth redirect URI.
-- `POST /vibe` – set the desired vibe prompt.
-- `GET /vibe` – retrieve the currently stored vibe.
 - `POST /playlist` – generate and save the playlist to your account.
 - `GET /profile` – return the authenticated user's profile.
 
@@ -67,7 +65,6 @@ A very small web frontend is provided under `static/`. When the API server is
 running you can open `http://localhost:8000/` to interact with it:
 
 1. Click **Login with Spotify** to authenticate.
-2. Enter your vibe and click **Set Vibe**.
-3. Press **Create Playlist** to generate and save the playlist. A link to the
-   playlist will be shown on success.
+2. Enter your vibe and press **Create Playlist** to generate and save the
+   playlist. A link to the playlist will be shown on success.
 

--- a/api.py
+++ b/api.py
@@ -25,8 +25,6 @@ sp_oauth = SpotifyOAuth(
     open_browser=False
 )
 
-# In-memory storage for user prompts
-user_prompts = {}
 
 @app.get("/login")
 def login():
@@ -43,25 +41,11 @@ def callback(request: Request):
         raise HTTPException(status_code=400, detail="Failed to get token")
     return RedirectResponse(url="/")
 
-@app.post("/vibe")
-def set_vibe(vibe: str):
-    if not vibe:
-        raise HTTPException(status_code=400, detail="Vibe required")
-    user_prompts['vibe'] = vibe
-    return {"vibe": vibe}
-
-@app.get("/vibe")
-def get_vibe():
-    vibe = user_prompts.get('vibe')
-    if not vibe:
-        raise HTTPException(status_code=404, detail="Vibe not set")
-    return {"vibe": vibe}
 
 @app.post("/playlist")
-def make_playlist():
-    vibe = user_prompts.get('vibe')
+def make_playlist(vibe: str):
     if not vibe:
-        raise HTTPException(status_code=400, detail="No vibe set")
+        raise HTTPException(status_code=400, detail="Vibe required")
     token_info = sp_oauth.get_cached_token()
     if not token_info:
         raise HTTPException(status_code=401, detail="Not authenticated")

--- a/static/app.js
+++ b/static/app.js
@@ -14,19 +14,13 @@ async function checkAuth() {
 
 checkAuth();
 
-document.getElementById('setVibe').addEventListener('click', async () => {
-    const vibe = document.getElementById('vibeInput').value;
-    const res = await fetch('/vibe?vibe=' + encodeURIComponent(vibe), {method: 'POST'});
-    if (res.ok) {
-        const data = await res.json();
-        document.getElementById('status').textContent = 'Vibe set to: ' + data.vibe;
-    } else {
-        document.getElementById('status').textContent = 'Failed to set vibe';
-    }
-});
 
 document.getElementById('createPlaylist').addEventListener('click', async () => {
-    const res = await fetch('/playlist', {method: 'POST'});
+    const vibe = document.getElementById('vibeInput').value;
+    const spinner = document.getElementById('spinner');
+    spinner.style.display = 'inline-block';
+    const res = await fetch('/playlist?vibe=' + encodeURIComponent(vibe), {method: 'POST'});
+    spinner.style.display = 'none';
     if (res.ok) {
         const data = await res.json();
         document.getElementById('status').innerHTML = '<a href="' + data.playlist_url + '" target="_blank">Open Playlist</a>';

--- a/static/index.html
+++ b/static/index.html
@@ -3,14 +3,29 @@
 <head>
     <meta charset="UTF-8">
     <title>LLM DJ</title>
+    <style>
+        .spinner {
+            border: 4px solid #f3f3f3;
+            border-top: 4px solid #3498db;
+            border-radius: 50%;
+            width: 24px;
+            height: 24px;
+            animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+    </style>
 </head>
 <body>
     <h1>LLM DJ</h1>
     <button id="login">Login with Spotify</button>
     <div id="loggedin" style="display:none;">
         <input type="text" id="vibeInput" placeholder="Describe your vibe">
-        <button id="setVibe">Set Vibe</button>
         <button id="createPlaylist">Create Playlist</button>
+        <div id="spinner" class="spinner" style="display:none;"></div>
         <p id="status"></p>
     </div>
     <script src="/static/app.js"></script>


### PR DESCRIPTION
## Summary
- simplify flow so `Create Playlist` also sets the vibe
- drop `/vibe` API endpoints
- update documentation
- show a spinner while the playlist request is running

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b0bbf7f388326886b6092bda4a43b